### PR TITLE
Use CFBundleName as fallback when CFBundleDisplayName is nil

### DIFF
--- a/Switchcraft.podspec
+++ b/Switchcraft.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Switchcraft'
-  s.version          = '0.1.1'
+  s.version          = '0.1.2'
   s.summary          = 'Drop and go endpoint selector written in Swift.'
   s.homepage         = 'https://github.com/steamclock/Switchcraft'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Switchcraft/Classes/Config.swift
+++ b/Switchcraft/Classes/Config.swift
@@ -30,15 +30,15 @@ public struct Config {
      * Default is the current build name and version number.
      */
     public var alertMessage: String? {
-        if let bundle = Bundle.main.infoDictionary,
-                let displayName = bundle["CFBundleDisplayName"] as? String,
-                let versionString = bundle["CFBundleShortVersionString"] as? String,
-                let buildNumber = bundle["CFBundleVersion"] as? String {
-            return displayName + " " + versionString + "-" + buildNumber
+        guard let bundle = Bundle.main.infoDictionary,
+            let displayName = (bundle["CFBundleDisplayName"] as? String) ?? (bundle["CFBundleName"] as? String),
+            let versionString = bundle["CFBundleShortVersionString"] as? String,
+            let buildNumber = bundle["CFBundleVersion"] as? String else {
+                return nil
         }
-        return nil
-    }
 
+        return displayName + " " + versionString + "-" + buildNumber
+    }
     /**
      * The alert view text field placeholder.
      * Default is "Enter Value".


### PR DESCRIPTION
Found that in some projects, the CFBundleDisplayName is nil, but still wanted to display the build information in Switchcraft. Also bumped the podspec up to 0.1.2.