### PR TITLE
Add custom actions to Switchcraft

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		03C78250F2EEC1A1DEBFB7A724CFAB86 /* Pods-Switchcraft_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B6AAA9450D01A0B34F397BD2E6C54759 /* Pods-Switchcraft_Tests-dummy.m */; };
 		04FE8DA00119F42EC617A1F3FE351227 /* Pods-Switchcraft_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 457CD9A9F3B4ED656B14A781E7E77DD4 /* Pods-Switchcraft_Example-dummy.m */; };
 		0CC9BD2E30770769D92DF75EBC101428 /* Pods-Switchcraft_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 73B463F37A18452B0F8F8BA860ED7220 /* Pods-Switchcraft_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		233E0BE320EED387005E5861 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233E0BE120EED381005E5861 /* Action.swift */; };
 		51FE2CEBC8172DE838AC5A76220ED8E3 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56C69C8EF46CA990096F064D5F5A7E47 /* Endpoint.swift */; };
 		576AC307A953ABA3D28BCD7832A28B5E /* Pods-Switchcraft_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 975A4A27F8385FB7F9E439F740A003E6 /* Pods-Switchcraft_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5B6D59E3C9C67B40D85CFE6E6B90905B /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EF6242E1911A948B07FD3D225373DC /* Config.swift */; };
@@ -45,6 +46,7 @@
 		142F09B265588B4BA499BF0880E48820 /* Pods-Switchcraft_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Switchcraft_Example-frameworks.sh"; sourceTree = "<group>"; };
 		145667BC9BCDFD1A4CBF6697E377A9CE /* Switchcraft.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Switchcraft.xcconfig; sourceTree = "<group>"; };
 		205D8D71751D92FAEF431F2EF8BB3428 /* Switchcraft.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Switchcraft.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		233E0BE120EED381005E5861 /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Action.swift; path = Switchcraft/Classes/Action.swift; sourceTree = "<group>"; };
 		241733F8B171E2CCC3A83FE37A19E176 /* Switchcraft.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Switchcraft.modulemap; sourceTree = "<group>"; };
 		2DC2B6485336298A3729B6F8C5A5AEE2 /* Pods-Switchcraft_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Switchcraft_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		340BE5F641A5CF241CEA0370AD3FCEA6 /* Pods-Switchcraft_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Switchcraft_Tests-frameworks.sh"; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 				56C69C8EF46CA990096F064D5F5A7E47 /* Endpoint.swift */,
 				A0B781607888266E05F21B73E0F7F560 /* Notification.swift */,
 				49F89A0A1DAC31F985D6E15AAB5DF214 /* Switchcraft.swift */,
+				233E0BE120EED381005E5861 /* Action.swift */,
 				E13EBA8C5A8D08BFD5FE2B69DFB68510 /* Pod */,
 				6FE96B096156932FE438B2D917693E47 /* Support Files */,
 			);
@@ -369,6 +372,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5B6D59E3C9C67B40D85CFE6E6B90905B /* Config.swift in Sources */,
+				233E0BE320EED387005E5861 /* Action.swift in Sources */,
 				51FE2CEBC8172DE838AC5A76220ED8E3 /* Endpoint.swift in Sources */,
 				B108C471060A1C19E52BC5FFF5E87010 /* Notification.swift in Sources */,
 				8AF720D46AEBB9A7F1C503B31716BEF9 /* Switchcraft-dummy.m in Sources */,

--- a/Example/Switchcraft/AppDelegate.swift
+++ b/Example/Switchcraft/AppDelegate.swift
@@ -28,12 +28,8 @@ extension Switchcraft {
             Endpoint(title: "Steamclock", url: URL(string: "http://steamclock.com")!)
         ],
         actions: [
-            Action(title: "Custom action 1") {
-                print("Tapped custom action 1")
-            },
-            Action(title: "Custom action 2") {
-                print("Tapped custom action 2")
-            }
+            Action(title: "Custom action 1", actionId: "custom1"),
+            Action(title: "Custom action 2", actionId: "custom2")
         ],
         allowCustom: true
     ))

--- a/Example/Switchcraft/AppDelegate.swift
+++ b/Example/Switchcraft/AppDelegate.swift
@@ -28,9 +28,14 @@ extension Switchcraft {
             Endpoint(title: "Steamclock", url: URL(string: "http://steamclock.com")!)
         ],
         actions: [
-            Action(title: "Custom action 1", actionId: "custom1"),
-            Action(title: "Custom action 2", actionId: "custom2")
+            Action(title: "Custom action 1", actionId: Actions.custom1.rawValue),
+            Action(title: "Custom action 2", actionId: Actions.custom2.rawValue)
         ],
         allowCustom: true
     ))
+}
+
+enum Actions: String {
+    case custom1
+    case custom2
 }

--- a/Example/Switchcraft/AppDelegate.swift
+++ b/Example/Switchcraft/AppDelegate.swift
@@ -27,6 +27,14 @@ extension Switchcraft {
             Endpoint(title: nil, url: URL(string: "http://apple.com")!),
             Endpoint(title: "Steamclock", url: URL(string: "http://steamclock.com")!)
         ],
+        actions: [
+            Action(title: "Custom action 1") {
+                print("Tapped custom action 1")
+            },
+            Action(title: "Custom action 2") {
+                print("Tapped custom action 2")
+            }
+        ],
         allowCustom: true
     ))
 }

--- a/Example/Switchcraft/ReallySimpleExampleVC.swift
+++ b/Example/Switchcraft/ReallySimpleExampleVC.swift
@@ -33,10 +33,16 @@ extension ReallySimpleExampleVC: SwitchcraftDelegate {
     }
 
     func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action) {
-        if action.actionId == "custom1" {
+        guard let action = Actions(rawValue: action.actionId) else {
+            return
+        }
+
+        switch action {
+        case .custom1:
             print("tapped action 1")
-        } else if action.actionId == "custom2" {
+        case .custom2:
             print("tapped action 2")
         }
+
     }
 }

--- a/Example/Switchcraft/ReallySimpleExampleVC.swift
+++ b/Example/Switchcraft/ReallySimpleExampleVC.swift
@@ -31,4 +31,12 @@ extension ReallySimpleExampleVC: SwitchcraftDelegate {
         currentEndpointLabel.isHidden = endpoint == switchcraft.defaultEndpoint
         currentEndpointLabel.text = "Current Endpoint:\n\(endpoint.name)"
     }
+
+    func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action) {
+        if action.actionId == "custom1" {
+            print("tapped action 1")
+        } else if action.actionId == "custom2" {
+            print("tapped action 2")
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To get updates whenever an endpoint is selected, you've got two options:
 1. Delegation
 
     If you only need to keep track of changes to the current endpoint in a single place, this is probably the way to go.
-    Classes that want to recieve updates only need to register your `viewController` as a delegate and conform to the `SwitchcraftDelegate` protocol.
+    Classes that want to receive updates only need to register your `viewController` as a delegate and conform to the `SwitchcraftDelegate` protocol.
 
     ```
     class MyVC: UIViewController {

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ To get updates whenever an endpoint is selected, you've got two options:
         func switchcraft(_ switchcraft: Switchcraft, didSelectEndpoint endpoint: Endpoint) {
             // Handle your endpoint selection here
         }
+        
+        func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action)
+            // Handle custom action selection here
+        }
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,6 @@ To get updates whenever an endpoint is selected, you've got two options:
         func switchcraft(_ switchcraft: Switchcraft, didSelectEndpoint endpoint: Endpoint) {
             // Handle your endpoint selection here
         }
-        
-        func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action)
-            // Handle custom action selection here
-        }
     }
     ```
 
@@ -91,6 +87,72 @@ To get updates whenever an endpoint is selected, you've got two options:
         // Handle endpoint selected here
     }
     ```
+
+### Custom Actions
+
+1. Add some custom actions to Switchcraft via the `Config`:
+```swift
+extension Switchcraft {
+    static let shared = Switchcraft(config: Config(
+            defaultsKey: ...,
+            endpoints: ...,
+            actions: [
+                Action(title: "Custom action 1", actionId: "customAction1"),
+                Action(title: "Custom action 2", actionId: "customAction2")
+            ]
+        ))
+}
+```
+
+2. Add the following to your SwitchCraftDelegate:
+```swift
+extension MyVC: SwitchcraftDelegate {
+    ...
+ 
+    func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action)
+        // Handle custom action selection here
+    }
+}
+```
+
+Note: We recommend using Swift enums for the actionId, like the following example:
+```swift
+enum Actions: String {
+    case custom1
+    case custom2
+}
+
+extension Switchcraft {
+    static let shared = Switchcraft(config: Config(
+            defaultsKey: ...,
+            endpoints: ...,
+            actions: [
+                Action(title: "Custom action 1", actionId: Actions.custom1.rawValue),
+                Action(title: "Custom action 2", actionId: Actions.custom2.rawValue)
+            ]
+        ))
+}
+
+extension MyVC: SwitchcraftDelegate {
+    ...
+
+    func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action) {
+        guard let action = Actions(rawValue: action.actionId) else {
+            return
+        }
+
+        switch action {
+        case .custom1:
+            // handle the first custom action tapped
+            ...
+        case .custom2:
+            // handle the second custom action tapped
+            ...
+        }
+    }
+}
+
+```
     
 ### Getting Fancy
 

--- a/Switchcraft.podspec
+++ b/Switchcraft.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Switchcraft'
-  s.version          = '0.1.3'
+  s.version          = '0.2.0'
   s.summary          = 'Drop and go endpoint selector written in Swift.'
   s.homepage         = 'https://github.com/steamclock/Switchcraft'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Switchcraft.podspec
+++ b/Switchcraft.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Switchcraft'
-  s.version          = '0.2.0'
+  s.version          = '1.0.0'
   s.summary          = 'Drop and go endpoint selector written in Swift.'
   s.homepage         = 'https://github.com/steamclock/Switchcraft'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Switchcraft.podspec
+++ b/Switchcraft.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Switchcraft'
-  s.version          = '0.1.2'
+  s.version          = '0.1.3'
   s.summary          = 'Drop and go endpoint selector written in Swift.'
   s.homepage         = 'https://github.com/steamclock/Switchcraft'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Switchcraft/Classes/Action.swift
+++ b/Switchcraft/Classes/Action.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  * Represents an action that can be tapped using the `Switchcraft` picker.
  */
-public struct Action: Codable {
+public struct Action {
     /**
      * A title to be shown for the action.
      */
@@ -30,14 +30,5 @@ public struct Action: Codable {
     public init(title: String, actionId: String) {
         self.title = title
         self.actionId = actionId
-    }
-}
-
-extension Action: Equatable {
-    /**
-     * Check equality between two Action.
-     */
-    public static func == (lhs: Action, rhs: Action) -> Bool {
-        return lhs.actionId == rhs.actionId
     }
 }

--- a/Switchcraft/Classes/Action.swift
+++ b/Switchcraft/Classes/Action.swift
@@ -1,0 +1,43 @@
+//
+//  Actions.swift
+//  Pods-Switchcraft_Example
+//
+//  Created by Jake on 2018-07-05.
+//
+
+import Foundation
+
+/**
+ * Represents an action that can be chosen using the `Switchcraft` picker.
+ */
+public struct Action {
+    /**
+     * A title to be shown for the action.
+     */
+    public let title: String
+
+    /**
+     * The callback for the action.
+     */
+    public let callback: () -> Void
+
+    /**
+     * Create a new action.
+     *
+     * - parameter title: The title to show in the endpoint selection menu.
+     * - parameter callback: The callback to call when chosen.
+     */
+    public init(title: String, callback: @escaping () -> Void) {
+        self.title = title
+        self.callback = callback
+    }
+}
+
+extension Action: Equatable {
+    /**
+     * Check equality between two Action.
+     */
+    public static func == (lhs: Action, rhs: Action) -> Bool {
+        return lhs.title == rhs.title
+    }
+}

--- a/Switchcraft/Classes/Action.swift
+++ b/Switchcraft/Classes/Action.swift
@@ -8,28 +8,28 @@
 import Foundation
 
 /**
- * Represents an action that can be chosen using the `Switchcraft` picker.
+ * Represents an action that can be tapped using the `Switchcraft` picker.
  */
-public struct Action {
+public struct Action: Codable {
     /**
      * A title to be shown for the action.
      */
     public let title: String
 
     /**
-     * The callback for the action.
+     * A unique ID for the action.
      */
-    public let callback: () -> Void
+    public let actionId: String
 
     /**
      * Create a new action.
      *
      * - parameter title: The title to show in the endpoint selection menu.
-     * - parameter callback: The callback to call when chosen.
+     * - parameter actionId: The unique identifier for the action.
      */
-    public init(title: String, callback: @escaping () -> Void) {
+    public init(title: String, actionId: String) {
         self.title = title
-        self.callback = callback
+        self.actionId = actionId
     }
 }
 
@@ -38,6 +38,6 @@ extension Action: Equatable {
      * Check equality between two Action.
      */
     public static func == (lhs: Action, rhs: Action) -> Bool {
-        return lhs.title == rhs.title
+        return lhs.actionId == rhs.actionId
     }
 }

--- a/Switchcraft/Classes/Config.swift
+++ b/Switchcraft/Classes/Config.swift
@@ -69,6 +69,11 @@ public struct Config {
     public var endpoints: [Endpoint] = []
 
     /**
+     * The set of custom actions to be shown in the switcher.
+     */
+    public var actions: [Action] = []
+
+    /**
      * The index of the default endpoint in `endpoints`.
      * Default is `0`.
      * If this index is invalid for any reason it will default to the first endpoint.
@@ -82,9 +87,10 @@ public struct Config {
      * - parameter endpoints: The set of endpoints to show in the picker.
      * - parameter allowCustom: Whether the switcher allows entering custom endpoints.
      */
-    public init(defaultsKey: String, endpoints: [Endpoint], allowCustom: Bool = false) {
+    public init(defaultsKey: String, endpoints: [Endpoint], actions: [Action] = [], allowCustom: Bool = false) {
         self.defaultsKey = defaultsKey
         self.endpoints = endpoints
         self.allowCustom = allowCustom
+        self.actions = actions
     }
 }

--- a/Switchcraft/Classes/Switchcraft.swift
+++ b/Switchcraft/Classes/Switchcraft.swift
@@ -21,6 +21,14 @@ public protocol SwitchcraftDelegate: AnyObject {
     func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action)
 }
 
+
+// provides a default extension, so other applications don't have to override the action handling
+extension SwitchcraftDelegate {
+    func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action) {
+        // no-op, allowing this method to be optional
+    }
+}
+
 /**
  * Switchcraft is a simple manager to make switching endpoints easier.
  *

--- a/Switchcraft/Classes/Switchcraft.swift
+++ b/Switchcraft/Classes/Switchcraft.swift
@@ -191,6 +191,19 @@ public class Switchcraft {
             })
         }
 
+        for action in config.actions {
+            alertController.addAction(
+                UIAlertAction(
+                    title: "Action: \(action.title)",
+                    style: .default,
+                    handler: { _ in
+                        action.callback()
+                        viewController.dismiss(animated: false, completion: nil)
+                    }
+                )
+            )
+        }
+
         alertController.addAction(
             UIAlertAction(
                 title: config.cancelTitle,

--- a/Switchcraft/Classes/Switchcraft.swift
+++ b/Switchcraft/Classes/Switchcraft.swift
@@ -23,7 +23,7 @@ public protocol SwitchcraftDelegate: AnyObject {
 
 
 // provides a default extension, so other applications don't have to override the action handling
-extension SwitchcraftDelegate {
+public extension SwitchcraftDelegate {
     func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action) {
         // no-op, allowing this method to be optional
     }

--- a/Switchcraft/Classes/Switchcraft.swift
+++ b/Switchcraft/Classes/Switchcraft.swift
@@ -14,6 +14,11 @@ public protocol SwitchcraftDelegate: AnyObject {
      * Called when an endpoint is selected.
      */
     func switchcraft(_ switchcraft: Switchcraft, didSelectEndpoint endpoint: Endpoint)
+
+    /**
+     * Called when an action is tapped.
+     */
+    func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action)
 }
 
 /**
@@ -196,8 +201,8 @@ public class Switchcraft {
                 UIAlertAction(
                     title: "Action: \(action.title)",
                     style: .default,
-                    handler: { _ in
-                        action.callback()
+                    handler: { [weak self] _ in
+                        self?.tapped(action: action)
                         viewController.dismiss(animated: false, completion: nil)
                     }
                 )
@@ -274,6 +279,15 @@ public class Switchcraft {
         self.endpoint = endpoint
         delegate?.switchcraft(self, didSelectEndpoint: endpoint)
         NotificationCenter.default.post(name: .SwitchcraftDidSelectEndpoint, object: self, userInfo: [Notification.Key.Endpoint: endpoint])
+    }
+
+    /**
+     * Called when an action is tapped.
+     *
+     * - parameter action: The action tapped.
+     */
+    private func tapped(action: Action) {
+        delegate?.switchcraft(self, didTapAction: action)
     }
 
     /**

--- a/Switchcraft/Classes/Switchcraft.swift
+++ b/Switchcraft/Classes/Switchcraft.swift
@@ -199,7 +199,7 @@ public class Switchcraft {
         for action in config.actions {
             alertController.addAction(
                 UIAlertAction(
-                    title: "Action: \(action.title)",
+                    title: action.title,
                     style: .default,
                     handler: { [weak self] _ in
                         self?.tapped(action: action)


### PR DESCRIPTION
Added the ability to have custom actions in Switchcraft. 

I bumped the podspec up to `0.2.0` to show breaking changes, but I think the more correct way would to bump it to `1.0.0`. Let me know if I should change it!