### PR TITLE
Migrate to Swift 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2019-01-08
+### Changed
+- Use Swift 4.2
+
 ## [1.1.0] - 2018-08-02
 ### Added
 - Added this changelog.

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -378,7 +378,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1010;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -782,6 +782,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Release;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -379,6 +379,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 1010;
+				TargetAttributes = {
+					D8A69CEF945E68648CAD7A6B417AB7A4 = {
+						LastSwiftMigration = 1010;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -623,7 +628,8 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.2;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -828,7 +834,8 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.2;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Example/Switchcraft.xcodeproj/project.pbxproj
+++ b/Example/Switchcraft.xcodeproj/project.pbxproj
@@ -490,7 +490,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -506,7 +506,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Example/Switchcraft/AppDelegate.swift
+++ b/Example/Switchcraft/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         return true
     }
 }

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ To get updates whenever an endpoint is selected, you've got two options:
     ```
     class MyVC: UIViewController {
         // ...
-        
+
         override func viewDidLoad() {
             super.viewDidLoad()
-            
+
             Switchcraft.delegate = self
         }
     }
-    
+
     extension MyVC: SwitchcraftDelegate {
         func switchcraft(_ switchcraft: Switchcraft, didSelectEndpoint endpoint: Endpoint) {
             // Handle your endpoint selection here
@@ -73,13 +73,13 @@ To get updates whenever an endpoint is selected, you've got two options:
 
 2. `NotificationCenter`
 
-    Endpoint selections are also broadcast to the `NotificationCenter`. 
-    
+    Endpoint selections are also broadcast to the `NotificationCenter`.
+
     ```
     NotificationCenter.default.addObserver(self, selector: #selector(endpointSelected(_:)), name: .SwitchcraftDidSelectEndpoint, object: nil)
-    
+
     ...
-    
+
     @objc private func endpointSelected(_ sender: NSNotification) {
         guard let endpoint = sender.userInfo?[Notification.Key.Endpoint] as? Endpoint else {
             return
@@ -108,7 +108,7 @@ extension Switchcraft {
 ```swift
 extension MyVC: SwitchcraftDelegate {
     ...
- 
+
     func switchcraft(_ switchcraft: Switchcraft, didTapAction action: Action)
         // Handle custom action selection here
     }
@@ -153,7 +153,7 @@ extension MyVC: SwitchcraftDelegate {
 }
 
 ```
-    
+
 ### Getting Fancy
 
 There are lots of knobs to tweak in your config. See [Config.swift](https://github.com/steamclock/switchcraft/blob/master/Switchcraft/Classes/Config.swift) for a full list.
@@ -165,8 +165,8 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 ## Requirements
 
 - iOS 9.3 or above
-- Xcode 8.2.1 or above
-- Swift 3.2 or above
+- Xcode 10 or above
+- Swift 4.2 or above
 
 ## Installation
 

--- a/Switchcraft.podspec
+++ b/Switchcraft.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Switchcraft'
-  s.version          = '1.1.0'
+  s.version          = '1.2.0'
   s.summary          = 'Drop and go endpoint selector written in Swift.'
   s.homepage         = 'https://github.com/steamclock/Switchcraft'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   'Switchcraft' => ['Switchcraft/*/Assets.xcassets']
   }
   s.source_files = 'Switchcraft/Classes/**/*'
-  s.swift_version = '3.2'
+  s.swift_version = '4.2'
 end


### PR DESCRIPTION
- No code changes needed in this migration
- Updated configurations in Xcode, podspec, readme, and changelog to make all Swift version specifiers point to 4.2