### PR TITLE
Update the package/target names with an initial capital letter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+# Finder hidden files
+.DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -4,19 +4,19 @@
 import PackageDescription
 
 let package = Package(
-    name: "switchcraft",
+    name: "Switchcraft",
     products: [
         .library(
-            name: "switchcraft",
-            targets: ["switchcraft"]),
+            name: "Switchcraft",
+            targets: ["Switchcraft"]),
     ],
     dependencies: [],
     targets: [
         .target(
-            name: "switchcraft",
+            name: "Switchcraft",
             dependencies: []),
         .testTarget(
             name: "switchcraftTests",
-            dependencies: ["switchcraft"]),
+            dependencies: ["Switchcraft"]),
     ]
 )


### PR DESCRIPTION
Otherwise, you have to import with `import switchcraft` which is pretty non-standard for Swift imports

Also includes a change to add .DS_Store to the .gitignore.