### PR TITLE
Replace Objective-C macro Swift macro

### DIFF
--- a/Sources/Switchcraft/Switchcraft.swift
+++ b/Sources/Switchcraft/Switchcraft.swift
@@ -396,9 +396,13 @@ public class Switchcraft {
         let defaultGesture = UITapGestureRecognizer(target: self, action: #selector(tapHandler(_:)))
 
         // Change default tap behaviour if running on the simulator to use a single tap
-        let isSimulator = TARGET_OS_SIMULATOR != 0
-        defaultGesture.numberOfTapsRequired = isSimulator ? 1 : 2
-        defaultGesture.numberOfTouchesRequired = isSimulator ? 1 : 3
+        #if targetEnvironment(simulator)
+        defaultGesture.numberOfTapsRequired =  1
+        defaultGesture.numberOfTouchesRequired = 1
+        #else
+        defaultGesture.numberOfTapsRequired = 2
+        defaultGesture.numberOfTouchesRequired = 3
+        #endif
         return defaultGesture
     }
 }


### PR DESCRIPTION
Since XCode 16.3 the compiler is not able to find the `TARGET_OS_SIMULATOR` macro anymore.

<img width="1017" height="116" alt="image" src="https://github.com/user-attachments/assets/23cf74b0-a3ba-4956-ac55-0cea717456de" />

This PR replaces the old macro with the newer Swift `targetEnvironment(simulator)` macro.